### PR TITLE
[chore] Update Go version to 1.25 and align GitHub Actions

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -48,7 +48,7 @@ jobs:
           docker push ${{ secrets.IMAGE_NAME }}:stable-${GITHUB_SHA::7}
       - name: Docker Hub Description
         if: github.event_name != 'pull_request' && startsWith(github.ref, 'refs/tags/') && success()
-        uses: peter-evans/dockerhub-description@v2
+        uses: peter-evans/dockerhub-description@v5
         env:
           DOCKERHUB_USERNAME: ${{ secrets.DOCKER_USERNAME }}
           DOCKERHUB_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
       - uses: actions/setup-go@master
         with:
-          go-version: 1.23.x
+          go-version: 1.25.0
           cache: true
           cache-dependency-path: go.sum
       - uses: actions/checkout@master
@@ -29,7 +29,7 @@ jobs:
       - name: set up Go
         uses: actions/setup-go@master
         with:
-          go-version: 1.23.x
+          go-version: 1.25.0
           cache: true
           cache-dependency-path: go.sum
       - uses: actions/checkout@master
@@ -47,14 +47,14 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@master
         with:
-          go-version: 1.23.x
+          go-version: 1.25.0
           cache: true
           cache-dependency-path: go.sum
       - name: Run unit tests
         run: go test --short ./... -race -coverprofile=coverage.txt -covermode=atomic
       - name: Upload coverage to Codecov
         if: github.repository == 'meshery/meshery-consul'
-        uses: codecov/codecov-action@v2.1.0
+        uses: codecov/codecov-action@v5
         with:
           files: ./coverage.txt
           flags: unittests
@@ -70,7 +70,7 @@ jobs:
     - name: Setup Go
       uses: actions/setup-go@master
       with:
-        go-version: 1.23.x
+        go-version: 1.25.0
         cache: true
         cache-dependency-path: go.sum
     - run: make gobuild

--- a/.github/workflows/multi-platform.yml
+++ b/.github/workflows/multi-platform.yml
@@ -110,7 +110,7 @@ jobs:
           platforms: linux/amd64,linux/arm64
       - 
         name: Docker Hub Description
-        uses: peter-evans/dockerhub-description@v2
+        uses: peter-evans/dockerhub-description@v5
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}

--- a/.github/workflows/slack.yml
+++ b/.github/workflows/slack.yml
@@ -17,7 +17,7 @@ jobs:
           echo "STARS=$(curl --silent 'https://api.github.com/repos/${{ github.repository }}' -H 'Accept: application/vnd.github.preview' | jq '.stargazers_count')" >> $GITHUB_ENV
 
       - name: Notify Slack
-        uses: slackapi/slack-github-action@v2.1.1
+        uses: slackapi/slack-github-action@v2
         with:
           method: chat.postMessage
           token: ${{ secrets.SLACK_BOT_TOKEN }}
@@ -32,7 +32,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Notify Slack
-        uses: slackapi/slack-github-action@v2.1.1
+        uses: slackapi/slack-github-action@v2
         with:
           method: chat.postMessage
           token: ${{ secrets.SLACK_BOT_TOKEN }}

--- a/.github/workflows/update-oam-defs.yml
+++ b/.github/workflows/update-oam-defs.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@master
         with:
-          go-version: 1.23
+          go-version: 1.25
       - name: Run adapter to create components
         run: |
           touch log.txt

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.23 as builder
+FROM golang:1.25 AS builder
 
 ARG VERSION
 ARG GIT_COMMITSHA

--- a/build/Makefile.core.mk
+++ b/build/Makefile.core.mk
@@ -19,7 +19,7 @@ GIT_VERSION	= $(shell git describe --tags `git rev-list --tags --max-count=1`)
 GIT_COMMITSHA = $(shell git rev-list -1 HEAD)
 GIT_STRIPPED_VERSION=$(shell git describe --tags `git rev-list --tags --max-count=1` | cut -c 2-)
 
-GOVERSION = 1.23
+GOVERSION = 1.25
 GOPATH = $(shell go env GOPATH)
 GOBIN  = $(GOPATH)/bin
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/layer5io/meshery-consul
 
-go 1.23
+go 1.25
 
 replace github.com/kudobuilder/kuttl => github.com/layer5io/kuttl v0.4.1-0.20200723152044-916f10574334
 


### PR DESCRIPTION
**Description**

This PR fixes #495 

**Changes made :**

- Updates the Go version used in this repository from 1.24 to 1.25.

- Updates GitHub Action version tags across the workflows to their latest stable releases.

**Notes for Reviewers**

**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**

- [X] Yes, I signed my commits.


