### PR TITLE
[meshery-consul] ci: globally disable ST1005 staticcheck lint rule

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,4 +1,6 @@
 linters-settings:
+  staticcheck:
+    checks: ["all", "-ST1005"]
   gci:
     enabled: true
     max-len: 120
@@ -49,6 +51,7 @@ linters:
     - unused
     - cyclop
     - scopelint
+    - staticcheck
   exclude-rules:
     - testpackage
 


### PR DESCRIPTION
### **Description**

This PR adds the `staticcheck` configuration to `.golangci.yml` to globally and permanently disable the **ST1005** (lowercase error strings) lint rule for the Consul adapter.

Fixes meshery/meshery#16867

### **Notes for Reviewers**

- Modified `.golangci.yml` to ignore ST1005 globally.
- Explicitly enabled `staticcheck` in the linters list.
- This ensures consistency across all Meshery adapters.

**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**

- [x] Yes, I signed my commits.