### PR TITLE
[CI] specify branch during checkout in e2etests

### DIFF
--- a/.github/workflows/e2etests.yaml
+++ b/.github/workflows/e2etests.yaml
@@ -80,7 +80,8 @@ jobs:
       - uses: actions/checkout@master
         with:
           repository: meshery/meshery 
-          token: ${{ secrets.GH_ACCESS_TOKEN }}   
+          token: ${{ secrets.GH_ACCESS_TOKEN }}
+          ref: master   
       - name: DownloadJSON
         uses: actions/download-artifact@master
         with:
@@ -123,5 +124,5 @@ jobs:
           commit_user_email: ci@layer5.io
           commit_author: ${{ github.actor }} <${{ github.actor }}@users.noreply.github.com>
           commit_options: '--signoff'
-          commit_message: '[Docs] Test status of adapter'  
-          
+          commit_message: '[Docs] Test status of adapter' 
+          branch: master


### PR DESCRIPTION
**Description**

This PR fixes #498.

The `UpdateDocsForServicemeshInstall` job in `e2etests.yaml` checks out the `meshery/meshery` repository to publish compatibility docs after e2e tests. Previously, `actions/checkout` was used without a `ref`, which left the job in **detached HEAD** state. When `git-auto-commit-action` tried to push the generated docs, it failed with:

fatal: You are not currently on a branch.

**Changes made:**
- Added `ref: master` to the `meshery/meshery` checkout step so the workflow checks out an actual branch instead of detached HEAD.
- Added `branch: master` to `git-auto-commit-action` so commits are pushed to the correct branch.

This aligns `e2etests.yaml` with the existing pattern used in `update-oam-defs.yml`, which already specifies both `ref` and `branch` for checkout + auto-commit workflows.

**Notes for Reviewers**

- This is a minimal CI-only change (1 file, 2 lines of functional config).
- No application/runtime code is affected.
- The fix targets the doc-publishing step that runs on `push` and `release` events (not on PRs).
- `meshery/meshery` default branch is `master`, consistent with other references in this workflow.

---
- [x] Yes, I signed my commits.